### PR TITLE
feat: add config field to show names. resolves #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ return {
         projects_config_filepath = vim.fs.normalize(vim.fn.stdpath("config") .. "/cd-project.nvim.json"),
         -- this controls the behaviour of `CdProjectAdd` command about how to get the project directory
         project_dir_pattern = { ".git", ".gitignore", "Cargo.toml", "package.json", "go.mod" },
+        projects_picker = "vim-ui", -- optional, you can switch to `telescope`
         -- do whatever you like by hooks
         hooks = {
           {
@@ -47,7 +48,6 @@ return {
             end,
           },
         },
-        projects_picker = "vim-ui", -- optional, you can switch to `telescope`
       })
     end,
   }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Note: `v0.3.0` displays name in project picker. before this version, the default name is `name place holder`, you can edit the json file directly to change it to a more meaningful name. Or only display the path of the projects you added by modify the `choice_format` option in the config.
+
 # cd-project.nvim
 
 I tried quite a lot `Project Management` plugins.
@@ -27,6 +29,7 @@ return {
         projects_config_filepath = vim.fs.normalize(vim.fn.stdpath("config") .. "/cd-project.nvim.json"),
         -- this controls the behaviour of `CdProjectAdd` command about how to get the project directory
         project_dir_pattern = { ".git", ".gitignore", "Cargo.toml", "package.json", "go.mod" },
+        choice_format = "both", -- optional, you can switch to "name" or "path"
         projects_picker = "vim-ui", -- optional, you can switch to `telescope`
         -- do whatever you like by hooks
         hooks = {

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -4,8 +4,7 @@ local api = require("cd-project.api")
 ---@param opts? table
 local cd_project = function(opts)
 	local utils = require("cd-project.utils")
-	local show_project_names = vim.g.cd_project_config.show_project_names
-	local success, picker = pcall(require, "telescope.pickers")
+	local success, _ = pcall(require, "telescope.pickers")
 	if not success then
 		utils.log_error("telescope not installed")
 		return

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -4,6 +4,7 @@ local api = require("cd-project.api")
 ---@param opts? table
 local cd_project = function(opts)
 	local utils = require("cd-project.utils")
+	local show_project_names = vim.g.cd_project_config.show_project_names
 	local success, picker = pcall(require, "telescope.pickers")
 	if not success then
 		utils.log_error("telescope not installed")
@@ -31,6 +32,13 @@ local cd_project = function(opts)
 				results = project.get_projects(),
 				---@param project_entry CdProject.Project
 				entry_maker = function(project_entry)
+					if show_project_names == true then
+						return {
+							value = project_entry,
+							display = project_entry.name,
+							ordinal = project_entry.path,
+						}
+					end
 					return {
 						value = project_entry,
 						display = project_entry.path,

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -42,7 +42,7 @@ local cd_project = function(opts)
 				entry_maker = function(project)
 					return {
 						value = project,
-						display = string.format("%-" .. maxLength .. "s", project.name) .. "  |  " .. project.path,
+						display = utils.format_entry(project, maxLength),
 						ordinal = project.path,
 					}
 				end,

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -1,4 +1,4 @@
-local project = require("cd-project.project-repo")
+local repo = require("cd-project.project-repo")
 local api = require("cd-project.api")
 
 ---@param opts? table
@@ -16,6 +16,14 @@ local cd_project = function(opts)
 	local actions = require("telescope.actions")
 	local action_state = require("telescope.actions.state")
 	opts = opts or {}
+	local projects = repo.get_projects()
+	local maxLength = 0
+	for _, project in ipairs(projects) do
+		if #project.name > maxLength then
+			maxLength = #project.name
+		end
+	end
+
 	pickers
 		.new(opts, {
 			attach_mappings = function(prompt_bufnr, map)
@@ -29,20 +37,13 @@ local cd_project = function(opts)
 			end,
 			prompt_title = "cd to project",
 			finder = finders.new_table({
-				results = project.get_projects(),
-				---@param project_entry CdProject.Project
-				entry_maker = function(project_entry)
-					if show_project_names == true then
-						return {
-							value = project_entry,
-							display = project_entry.name,
-							ordinal = project_entry.path,
-						}
-					end
+				results = projects,
+				---@param project CdProject.Project
+				entry_maker = function(project)
 					return {
-						value = project_entry,
-						display = project_entry.path,
-						ordinal = project_entry.path,
+						value = project,
+						display = string.format("%-" .. maxLength .. "s", project.name) .. "  |  " .. project.path,
+						ordinal = project.path,
 					}
 				end,
 			}),

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -17,7 +17,7 @@ local function cd_project(opts)
 	vim.ui.select(projects, {
 		prompt = "Select a directory",
 		format_item = function(project)
-			return string.format("%-" .. maxLength .. "s", project.name) .. "  |  " .. project.path
+			return utils.format_entry(project, maxLength)
 		end,
 	}, function(selected)
 		if not selected then

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -1,47 +1,29 @@
 local utils = require("cd-project.utils")
 local api = require("cd-project.api")
-local projects_repo = require("cd-project.project-repo")
+local repo = require("cd-project.project-repo")
 
 ---@param opts? table
 local function cd_project(opts)
 	opts = opts or {}
-	-- Determine whether to show project names or paths
-	local api_func
-	local show_project_names = vim.g.cd_project_config.show_project_names
-	if show_project_names == true then
-		api_func = api.get_project_names()
-	else
-		api_func = api.get_project_paths()
+	local projects = repo.get_projects()
+
+	local maxLength = 0
+	for _, project in ipairs(projects) do
+		if #project.name > maxLength then
+			maxLength = #project.name
+		end
 	end
 
-	vim.ui.select(api_func, {
+	vim.ui.select(projects, {
 		prompt = "Select a directory",
+		format_item = function(project)
+			return string.format("%-" .. maxLength .. "s", project.name) .. "  |  " .. project.path
+		end,
 	}, function(selected)
 		if not selected then
 			return utils.log_error("Must select a valid dir")
 		end
-
-		--[[HACK:
-        --  vague2k: A list of names is passed to vim.ui.select() based on the choice (name)
-        --  we loop through the array of projects and check if the project's name at that index
-        --  matches the option that was chosen. 
-        --  If it matches assign the projects path to selected_dir and break the loop.
-        --]]
-
-		if show_project_names == true then
-			local projects = projects_repo.get_projects()
-			local selected_dir
-			for _, project in ipairs(projects) do
-				if project.name == selected then
-					selected_dir = project.path
-					break
-				end
-			end
-			api.cd_project(selected_dir)
-		else
-			-- If showing project paths, use the selected path directly
-			api.cd_project(selected)
-		end
+		api.cd_project(selected.path)
 	end)
 end
 

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -1,16 +1,47 @@
 local utils = require("cd-project.utils")
 local api = require("cd-project.api")
+local projects_repo = require("cd-project.project-repo")
 
 ---@param opts? table
 local function cd_project(opts)
 	opts = opts or {}
-	vim.ui.select(api.get_project_paths(), {
+	-- Determine whether to show project names or paths
+	local api_func
+	local show_project_names = vim.g.cd_project_config.show_project_names
+	if show_project_names == true then
+		api_func = api.get_project_names()
+	else
+		api_func = api.get_project_paths()
+	end
+
+	vim.ui.select(api_func, {
 		prompt = "Select a directory",
-	}, function(dir)
-		if not dir then
+	}, function(selected)
+		if not selected then
 			return utils.log_error("Must select a valid dir")
 		end
-		api.cd_project(dir)
+
+		--[[HACK:
+        --  vague2k: A list of names is passed to vim.ui.select() based on the choice (name)
+        --  we loop through the array of projects and check if the project's name at that index
+        --  matches the option that was chosen. 
+        --  If it matches assign the projects path to selected_dir and break the loop.
+        --]]
+
+		if show_project_names == true then
+			local projects = projects_repo.get_projects()
+			local selected_dir
+			for _, project in ipairs(projects) do
+				if project.name == selected then
+					selected_dir = project.path
+					break
+				end
+			end
+			api.cd_project(selected_dir)
+		else
+			-- If showing project paths, use the selected path directly
+			api.cd_project(selected)
+		end
 	end)
 end
 

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -74,7 +74,7 @@ local function add_current_project()
 
 	local new_project = {
 		path = project_dir,
-		name = "name place holder", -- TODO: allow user to edit the name of the project
+		name = utils.get_tail_of_path(project_dir),
 	}
 	table.insert(projects, new_project)
 	project.write_projects(projects)
@@ -92,8 +92,6 @@ end
 return {
 	cd_project = cd_project,
 	add_current_project = add_current_project,
-	get_project_paths = get_project_paths,
-	get_project_names = get_project_names,
 	back = back,
 	find_project_dir = find_project_dir,
 }

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -36,6 +36,16 @@ local function get_project_paths()
 	return paths
 end
 
+---@return string[]
+local function get_project_names()
+	local projects = project.get_projects()
+	local path_names = {}
+	for _, value in ipairs(projects) do
+		table.insert(path_names, value.name)
+	end
+	return path_names
+end
+
 ---@param dir string
 local function cd_project(dir)
 	vim.g.cd_project_last_project = vim.g.cd_project_current_project
@@ -83,6 +93,7 @@ return {
 	cd_project = cd_project,
 	add_current_project = add_current_project,
 	get_project_paths = get_project_paths,
+	get_project_names = get_project_names,
 	back = back,
 	find_project_dir = find_project_dir,
 }

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -4,6 +4,7 @@
 ---@field projects_config_filepath string
 ---@field project_dir_pattern string[]
 ---@field projects_picker? CdProject.Adapter
+---@field show_project_names boolean
 ---@field hooks? CdProject.Hook[]
 
 ---@type CdProject.Config
@@ -14,7 +15,9 @@ local default_config = {
 	-- this controls the behaviour of `CdProjectAdd` command about how to get the project directory
 	project_dir_pattern = { ".git", ".gitignore", "Cargo.toml", "package.json", "go.mod" },
 	projects_picker = "vim-ui", -- optional, you can switch to `telescope`
-  -- do whatever you like by hooks
+	-- show_project_name: If true, selection will replace project paths with project names according to json.
+	show_project_names = false,
+	-- do whatever you like by hooks
 	hooks = {
 		{
 			callback = function(dir)

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -4,7 +4,6 @@
 ---@field projects_config_filepath string
 ---@field project_dir_pattern string[]
 ---@field projects_picker? CdProject.Adapter
----@field show_project_names boolean
 ---@field hooks? CdProject.Hook[]
 
 ---@type CdProject.Config
@@ -15,8 +14,6 @@ local default_config = {
 	-- this controls the behaviour of `CdProjectAdd` command about how to get the project directory
 	project_dir_pattern = { ".git", ".gitignore", "Cargo.toml", "package.json", "go.mod" },
 	projects_picker = "vim-ui", -- optional, you can switch to `telescope`
-	-- show_project_name: If true, selection will replace project paths with project names according to json.
-	show_project_names = false,
 	-- do whatever you like by hooks
 	hooks = {
 		{

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -1,8 +1,10 @@
 ---@alias CdProject.Adapter "telescope"|"vim-ui"
+---@alias CdProject.ChoiceFormat "name"|"path"|"both"
 
 ---@class CdProject.Config
 ---@field projects_config_filepath string
 ---@field project_dir_pattern string[]
+---@field choice_format? CdProject.ChoiceFormat
 ---@field projects_picker? CdProject.Adapter
 ---@field hooks? CdProject.Hook[]
 
@@ -13,6 +15,7 @@ local default_config = {
 	projects_config_filepath = vim.fs.normalize(vim.fn.stdpath("config") .. "/cd-project.nvim.json"),
 	-- this controls the behaviour of `CdProjectAdd` command about how to get the project directory
 	project_dir_pattern = { ".git", ".gitignore", "Cargo.toml", "package.json", "go.mod" },
+	choice_format = "both", -- optional, you can switch to "name" or "path"
 	projects_picker = "vim-ui", -- optional, you can switch to `telescope`
 	-- do whatever you like by hooks
 	hooks = {

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -11,7 +11,23 @@ local function get_tail_of_path(path)
 	return path:match("([^/]+)$")
 end
 
+---@param project CdProject.Project
+---@param max_len integer
+local function format_entry(project, max_len)
+	local format = vim.g.cd_project_config.choice_format
+	if format == "both" then
+		return string.format("%-" .. max_len .. "s", project.name) .. "  |  " .. project.path
+	end
+	if format == "name" then
+		return project.name
+	end
+	if format == "path" then
+		return project.path
+	end
+end
+
 return {
 	log_error = log_error,
 	get_tail_of_path = get_tail_of_path,
+	format_entry = format_entry,
 }

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -1,5 +1,3 @@
-local M = {}
-
 ---@param msg string
 local function log_error(msg)
 	vim.notify(msg, vim.log.levels.ERROR, { title = "cd-project.nvim" })

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -13,15 +13,13 @@ end
 ---@param max_len integer
 local function format_entry(project, max_len)
 	local format = vim.g.cd_project_config.choice_format
-	if format == "both" then
-		return string.format("%-" .. max_len .. "s", project.name) .. "  |  " .. project.path
-	end
 	if format == "name" then
 		return project.name
 	end
 	if format == "path" then
 		return project.path
 	end
+	return string.format("%-" .. max_len .. "s", project.name) .. "  |  " .. project.path
 end
 
 return {

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -5,6 +5,13 @@ local function log_error(msg)
 	vim.notify(msg, vim.log.levels.ERROR, { title = "cd-project.nvim" })
 end
 
+---@param path string
+local function get_tail_of_path(path)
+	-- Remove leading directories, keep the last part
+	return path:match("([^/]+)$")
+end
+
 return {
 	log_error = log_error,
+	get_tail_of_path = get_tail_of_path,
 }


### PR DESCRIPTION
## What does this PR do?
- Add a config field called `show_project_names` which is a boolean
- Checks in telescope and vim-ui adapters to check if the `show_project_names` is true

### Telescope implementation
Fairly straight forward
Add a check in `pickers.finder.entry_maker` field in `telescope.lua`  to see if `show_project_names` is true
If it is true, `display = project.name`

### Vim.ui implementation
A bit tricky, i left a `HACK:` comment
We pass an array of project names to show as a list of possible choices. We then loop over all json objects (projects) in the json file and if the choice matches the name property in the object, we use the objects path property as the value to pass to `api.cd_project`