### PR TITLE
feat: Manually add dirs. resolves #10

### DIFF
--- a/lua/cd-project/adapter/init.lua
+++ b/lua/cd-project/adapter/init.lua
@@ -7,6 +7,11 @@ local function cd_project()
 	require("cd-project.adapter.vim-ui").cd_project()
 end
 
+local function manual_cd_project()
+	require("cd-project.adapter.vim-ui").manual_cd_project()
+end
+
 return {
 	cd_project = cd_project,
+	manual_cd_project = manual_cd_project,
 }

--- a/lua/cd-project/adapter/init.lua
+++ b/lua/cd-project/adapter/init.lua
@@ -8,6 +8,10 @@ local function cd_project()
 end
 
 local function manual_cd_project()
+	local projects_picker = vim.g.cd_project_config.projects_picker
+	if projects_picker == "telescope" then
+		return require("cd-project.adapter.telescope").manual_cd_project()
+	end
 	require("cd-project.adapter.vim-ui").manual_cd_project()
 end
 

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -9,7 +9,6 @@ local finders = require("telescope.finders")
 local conf = require("telescope.config").values
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
-local action_set = require("telescope.actions.set")
 
 local repo = require("cd-project.project-repo")
 local api = require("cd-project.api")
@@ -27,7 +26,7 @@ local cd_project = function(opts)
 
 	pickers
 		.new(opts, {
-			attach_mappings = function(prompt_bufnr, map)
+			attach_mappings = function(prompt_bufnr)
 				actions.select_default:replace(function()
 					actions.close(prompt_bufnr)
 					---@type CdProject.Project
@@ -56,12 +55,6 @@ end
 local manual_cd_project = function(opts)
 	opts = opts or {}
 
-	-- TODO: test on windows, most likely does not because windows is dookie and wants
-	-- to be different SOOO bad
-	--
-	-- most likely will need to handle how cwd property in jobstart is handled for windows... %USERPROFILE% ???
-
-	-- check if the find or fd command exists on the users system
 	local find_command = utils.check_for_find_cmd()
 	if not find_command then
 		utils.log_error("You need to install fd or find.")
@@ -71,6 +64,7 @@ local manual_cd_project = function(opts)
 	-- Harding coding the Home directory as a starting point for finding
 	-- directories is desireable since it's very unlikely a user will have
 	-- a project worth adding to the cd list in any parent dir relative to the home dir.
+	-- On Windows: ~ == "<drive>:/Users/<user>"
 	vim.fn.jobstart(find_command, {
 		cwd = vim.fn.expand("~"),
 		stdout_buffered = true,
@@ -81,27 +75,27 @@ local manual_cd_project = function(opts)
 						actions.select_default:replace(function()
 							actions.close(prompt_bufnr)
 							local selected_dir = action_state.get_selected_entry().value
-							local formatted_path = vim.fn.expand("~") .. "/" .. selected_dir
+							local formatted_path = utils.format_dir_based_on_os(selected_dir)
 
-							-- TODO: using vim.ui for name input feels hacky...
-							-- if there's a way to use telescope instead of vim.ui for this, that would be preferred
 							vim.ui.input({ prompt = "Add a project name: " }, function(name)
-								if not name then
-									utils.log_error("Quit command from name input, dir was not added")
-									return
-								end
-
-								if name == "" then
+								if not name or name == "" then
 									vim.notify(
 										'No name given, using "'
 											.. utils.get_tail_of_path(formatted_path)
 											.. '" instead'
 									)
-									api.add_project(formatted_path)
-									return
+									local project = api.build_project_obj(formatted_path)
+									if not project then
+										return
+									end
+									return api.add_project(project)
 								end
 
-								api.add_project(formatted_path, name)
+								local project = api.build_project_obj(formatted_path, name)
+								if not project then
+									return
+								end
+								return api.add_project(project)
 							end)
 						end)
 						return true

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -117,8 +117,6 @@ local manual_cd_project = function(opts)
 	})
 end
 
-manual_cd_project()
-
 return {
 	cd_project = cd_project,
 	manual_cd_project = manual_cd_project,

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -1,19 +1,21 @@
+local utils = require("cd-project.utils")
+local success, _ = pcall(require, "telescope.pickers")
+if not success then
+	utils.log_error("telescope not installed")
+	return
+end
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local conf = require("telescope.config").values
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local action_set = require("telescope.actions.set")
+
 local repo = require("cd-project.project-repo")
 local api = require("cd-project.api")
 
 ---@param opts? table
 local cd_project = function(opts)
-	local utils = require("cd-project.utils")
-	local success, _ = pcall(require, "telescope.pickers")
-	if not success then
-		utils.log_error("telescope not installed")
-		return
-	end
-	local pickers = require("telescope.pickers")
-	local finders = require("telescope.finders")
-	local conf = require("telescope.config").values
-	local actions = require("telescope.actions")
-	local action_state = require("telescope.actions.state")
 	opts = opts or {}
 	local projects = repo.get_projects()
 	local maxLength = 0
@@ -51,6 +53,73 @@ local cd_project = function(opts)
 		:find()
 end
 
+local manual_cd_project = function(opts)
+	opts = opts or {}
+
+	-- TODO: test on windows, most likely does not because windows is dookie and wants
+	-- to be different SOOO bad
+	--
+	-- most likely will need to handle how cwd property in jobstart is handled for windows... %USERPROFILE% ???
+
+	-- check if the find or fd command exists on the users system
+	local find_command = utils.check_for_find_cmd()
+	if not find_command then
+		utils.log_error("You need to install fd or find.")
+		return
+	end
+
+	-- Harding coding the Home directory as a starting point for finding
+	-- directories is desireable since it's very unlikely a user will have
+	-- a project worth adding to the cd list in any parent dir relative to the home dir.
+	vim.fn.jobstart(find_command, {
+		cwd = vim.fn.expand("~"),
+		stdout_buffered = true,
+		on_stdout = function(_, data)
+			pickers
+				.new(opts, {
+					attach_mappings = function(prompt_bufnr)
+						actions.select_default:replace(function()
+							actions.close(prompt_bufnr)
+							local selected_dir = action_state.get_selected_entry().value
+							local formatted_path = vim.fn.expand("~") .. "/" .. selected_dir
+
+							-- TODO: using vim.ui for name input feels hacky...
+							-- if there's a way to use telescope instead of vim.ui for this, that would be preferred
+							vim.ui.input({ prompt = "Add a project name: " }, function(name)
+								if not name then
+									utils.log_error("Quit command from name input, dir was not added")
+									return
+								end
+
+								if name == "" then
+									vim.notify(
+										'No name given, using "'
+											.. utils.get_tail_of_path(formatted_path)
+											.. '" instead'
+									)
+									api.add_project(formatted_path)
+									return
+								end
+
+								api.add_project(formatted_path, name)
+							end)
+						end)
+						return true
+					end,
+					prompt_title = "Select dir to add",
+					finder = finders.new_table({
+						results = data,
+					}),
+					sorter = conf.file_sorter(opts),
+				})
+				:find()
+		end,
+	})
+end
+
+manual_cd_project()
+
 return {
 	cd_project = cd_project,
+	manual_cd_project = manual_cd_project,
 }

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -4,39 +4,43 @@ local repo = require("cd-project.project-repo")
 
 ---@param opts? table
 local function cd_project(opts)
-	opts = opts or {}
-	local projects = repo.get_projects()
+    opts = opts or {}
+    local projects = repo.get_projects()
 
-	local maxLength = 0
-	for _, project in ipairs(projects) do
-		if #project.name > maxLength then
-			maxLength = #project.name
-		end
-	end
+    local maxLength = 0
+    for _, project in ipairs(projects) do
+        if #project.name > maxLength then
+            maxLength = #project.name
+        end
+    end
 
-	vim.ui.select(projects, {
-		prompt = "Select a directory",
-		format_item = function(project)
-			return utils.format_entry(project, maxLength)
-		end,
-	}, function(selected)
-		if not selected then
-			return utils.log_error("Must select a valid dir")
-		end
-		api.cd_project(selected.path)
-	end)
+    vim.ui.select(projects, {
+        prompt = "Select a directory",
+        format_item = function(project)
+            return utils.format_entry(project, maxLength)
+        end,
+    }, function(selected)
+        if not selected then
+            return utils.log_error("Must select a valid dir")
+        end
+        api.cd_project(selected.path)
+    end)
 end
 
 local function manual_cd_project()
-	-- ISSUE: vague2k: was getting weird behavior using a nested vim.ui.input() callback
-	-- and could not find appropriate docs or resources to help
-	-- ui is very bare bones but it works as intended
-	local final_path = vim.fn.input("Enter path: ")
-	local final_name = vim.fn.input("Enter name (optional): ")
-	api.add_project(final_path, final_name)
+    -- TODO: needs error handling, but works as intended
+    vim.ui.input({ prompt = "Add a project path: " }, function(path)
+        local final_path
+        final_path = path
+        vim.ui.input({ prompt = "Add a project name: " }, function(name)
+            local final_name
+            final_name = name
+            api.add_project(final_path, final_name)
+        end)
+    end)
 end
 
 return {
-	cd_project = cd_project,
-	manual_cd_project = manual_cd_project,
+    cd_project = cd_project,
+    manual_cd_project = manual_cd_project,
 }

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -30,11 +30,29 @@ end
 local function manual_cd_project()
 	-- TODO: needs error handling, but works as intended
 	vim.ui.input({ prompt = "Add a project path: " }, function(path)
+		if not path or path == "" then
+			utils.log_error("No path given, quitting.")
+			return
+		end
+
 		local final_path
 		final_path = path
+
 		vim.ui.input({ prompt = "Add a project name: " }, function(name)
+			if not name then
+				utils.log_error("Quit command from name input, dir was not added")
+				return
+			end
+
+			if name == "" then
+				vim.notify('No name given, using "' .. utils.get_tail_of_path(final_path) .. '" instead')
+				api.add_project(final_path)
+				return
+			end
+
 			local final_name
 			final_name = name
+
 			api.add_project(final_path, final_name)
 		end)
 	end)

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -30,8 +30,7 @@ end
 local function manual_cd_project()
 	vim.ui.input({ prompt = "Add a project path: " }, function(path)
 		if not path or path == "" then
-			utils.log_error("No path given, quitting.")
-			return
+			return utils.log_error("No path given, quitting.")
 		end
 
 		vim.ui.input({ prompt = "Add a project name: " }, function(name)
@@ -40,7 +39,12 @@ local function manual_cd_project()
 				return api.add_project(path)
 			end
 
-			return api.add_project(path, name)
+			local project = api.build_project_obj(path, name)
+			if not project then
+				return
+			end
+
+			return api.add_project(project)
 		end)
 	end)
 end

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -28,32 +28,19 @@ local function cd_project(opts)
 end
 
 local function manual_cd_project()
-	-- TODO: needs error handling, but works as intended
 	vim.ui.input({ prompt = "Add a project path: " }, function(path)
 		if not path or path == "" then
 			utils.log_error("No path given, quitting.")
 			return
 		end
 
-		local final_path
-		final_path = path
-
 		vim.ui.input({ prompt = "Add a project name: " }, function(name)
-			if not name then
-				utils.log_error("Quit command from name input, dir was not added")
-				return
+			if not name or name == "" then
+				vim.notify('No name given, using "' .. utils.get_tail_of_path(path) .. '" instead')
+				return api.add_project(path)
 			end
 
-			if name == "" then
-				vim.notify('No name given, using "' .. utils.get_tail_of_path(final_path) .. '" instead')
-				api.add_project(final_path)
-				return
-			end
-
-			local final_name
-			final_name = name
-
-			api.add_project(final_path, final_name)
+			return api.add_project(path, name)
 		end)
 	end)
 end

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -4,43 +4,43 @@ local repo = require("cd-project.project-repo")
 
 ---@param opts? table
 local function cd_project(opts)
-    opts = opts or {}
-    local projects = repo.get_projects()
+	opts = opts or {}
+	local projects = repo.get_projects()
 
-    local maxLength = 0
-    for _, project in ipairs(projects) do
-        if #project.name > maxLength then
-            maxLength = #project.name
-        end
-    end
+	local maxLength = 0
+	for _, project in ipairs(projects) do
+		if #project.name > maxLength then
+			maxLength = #project.name
+		end
+	end
 
-    vim.ui.select(projects, {
-        prompt = "Select a directory",
-        format_item = function(project)
-            return utils.format_entry(project, maxLength)
-        end,
-    }, function(selected)
-        if not selected then
-            return utils.log_error("Must select a valid dir")
-        end
-        api.cd_project(selected.path)
-    end)
+	vim.ui.select(projects, {
+		prompt = "Select a directory",
+		format_item = function(project)
+			return utils.format_entry(project, maxLength)
+		end,
+	}, function(selected)
+		if not selected then
+			return utils.log_error("Must select a valid dir")
+		end
+		api.cd_project(selected.path)
+	end)
 end
 
 local function manual_cd_project()
-    -- TODO: needs error handling, but works as intended
-    vim.ui.input({ prompt = "Add a project path: " }, function(path)
-        local final_path
-        final_path = path
-        vim.ui.input({ prompt = "Add a project name: " }, function(name)
-            local final_name
-            final_name = name
-            api.add_project(final_path, final_name)
-        end)
-    end)
+	-- TODO: needs error handling, but works as intended
+	vim.ui.input({ prompt = "Add a project path: " }, function(path)
+		local final_path
+		final_path = path
+		vim.ui.input({ prompt = "Add a project name: " }, function(name)
+			local final_name
+			final_name = name
+			api.add_project(final_path, final_name)
+		end)
+	end)
 end
 
 return {
-    cd_project = cd_project,
-    manual_cd_project = manual_cd_project,
+	cd_project = cd_project,
+	manual_cd_project = manual_cd_project,
 }

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -27,6 +27,16 @@ local function cd_project(opts)
 	end)
 end
 
+local function manual_cd_project()
+	-- ISSUE: vague2k: was getting weird behavior using a nested vim.ui.input() callback
+	-- and could not find appropriate docs or resources to help
+	-- ui is very bare bones but it works as intended
+	local final_path = vim.fn.input("Enter path: ")
+	local final_name = vim.fn.input("Enter name (optional): ")
+	api.add_project(final_path, final_name)
+end
+
 return {
 	cd_project = cd_project,
+	manual_cd_project = manual_cd_project,
 }

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -59,34 +59,13 @@ local function cd_project(dir)
 	end
 end
 
-local function add_current_project()
-	local project_dir = find_project_dir()
-
-	if not project_dir then
-		return utils.log_err("Can't find project path of current file")
-	end
-
-	local projects = project.get_projects()
-
-	if vim.tbl_contains(get_project_paths(), project_dir) then
-		return vim.notify("Project already exists: " .. project_dir)
-	end
-
-	local new_project = {
-		path = project_dir,
-		name = utils.get_tail_of_path(project_dir),
-	}
-	table.insert(projects, new_project)
-	project.write_projects(projects)
-	vim.notify("Project added: \n" .. project_dir)
-end
-
----@param name string
 ---@param path string
+---@param name? string
 ---@return string|nil
 --- HACK: vague2k: probably a better way of doing this?
-local function add_project(name, path)
+local function add_project(path, name)
 	local normalized_path = vim.fn.expand(path)
+	name = utils.get_tail_of_path(path) or name
 	if vim.fn.isdirectory(normalized_path) == 0 then
 		return nil
 	end
@@ -94,7 +73,7 @@ local function add_project(name, path)
 	local projects = project.get_projects()
 
 	if vim.tbl_contains(get_project_paths(), normalized_path) then
-		return normalized_path
+		return vim.notify("Project already exists: " .. normalized_path)
 	end
 
 	local new_project = {
@@ -104,7 +83,18 @@ local function add_project(name, path)
 
 	table.insert(projects, new_project)
 	project.write_projects(projects)
+	vim.notify("Project added: \n" .. normalized_path)
 	return normalized_path
+end
+
+local function add_current_project()
+	local project_dir = find_project_dir()
+
+	if not project_dir then
+		return utils.log_err("Can't find project path of current file")
+	end
+
+	add_project(project_dir)
 end
 
 local function back()

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -81,6 +81,33 @@ local function add_current_project()
 	vim.notify("Project added: \n" .. project_dir)
 end
 
+---@param name string
+---@param path string
+---@return string|nil
+
+--- HACK: vague2k: probably a better way of doing this?
+local function add_project(name, path)
+	local normalized_path = vim.fn.expand(path)
+	if vim.fn.isdirectory(normalized_path) == 0 then
+		return nil
+	end
+
+	local projects = project.get_projects()
+
+	if vim.tbl_contains(get_project_paths(), normalized_path) then
+		return normalized_path
+	end
+
+	local new_project = {
+		path = normalized_path,
+		name = name,
+	}
+
+	table.insert(projects, new_project)
+	project.write_projects(projects)
+	return normalized_path
+end
+
 local function back()
 	local last_project = vim.g.cd_project_last_project
 	if not last_project then
@@ -92,6 +119,7 @@ end
 return {
 	cd_project = cd_project,
 	add_current_project = add_current_project,
+	add_project = add_project,
 	back = back,
 	find_project_dir = find_project_dir,
 }

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -62,6 +62,8 @@ end
 ---@param path string
 ---@param name? string
 ---@return string|nil
+--- Add a project manually with a path, and optionally, a name.
+---
 --- HACK: vague2k: probably a better way of doing this?
 local function add_project(path, name)
 	local normalized_path = vim.fn.expand(path)

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -59,6 +59,23 @@ local function cd_project(dir)
 	end
 end
 
+---@param path string
+---@param name? string
+---@param desc? string|nil
+---@return CdProject.Project|nil
+local function build_project_obj(path, name, desc)
+	local normalized_path = vim.fn.expand(path)
+	if vim.fn.isdirectory(normalized_path) == 0 then
+		return utils.log_error(normalized_path .. " is not a directory")
+	end
+
+	return {
+		path = normalized_path,
+		name = name or utils.get_tail_of_path(normalized_path),
+		desc = desc,
+	}
+end
+
 ---@param project CdProject.Project
 local function add_project(project)
 	local projects = repo.get_projects()
@@ -66,12 +83,6 @@ local function add_project(project)
 	if vim.tbl_contains(get_project_paths(), project.path) then
 		return vim.notify("Project already exists: " .. project.path)
 	end
-
-	-- build PROJECT outside of this function, pass to this function as a whole
-	-- local new_project = {
-	-- 	path = normalized_path,
-	-- 	name = name,
-	-- }
 
 	table.insert(projects, project)
 	repo.write_projects(projects)
@@ -85,8 +96,13 @@ local function add_current_project()
 		return utils.log_err("Can't find project path of current file")
 	end
 
-  -- build a project object then pass to add_project function
-	add_project(project_dir)
+	local project = build_project_obj(project_dir)
+
+	if not project then
+		return
+	end
+
+	add_project(project)
 end
 
 local function back()
@@ -99,6 +115,9 @@ end
 
 return {
 	cd_project = cd_project,
+	build_project_obj = build_project_obj,
+	get_project_paths = get_project_paths,
+	get_project_names = get_project_names,
 	add_current_project = add_current_project,
 	add_project = add_project,
 	back = back,

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -84,7 +84,6 @@ end
 ---@param name string
 ---@param path string
 ---@return string|nil
-
 --- HACK: vague2k: probably a better way of doing this?
 local function add_project(name, path)
 	local normalized_path = vim.fn.expand(path)

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -8,7 +8,7 @@ local function get_tail_of_path(path)
 	-- Remove leading directories, keep the last part
 	local tail = path:match("([^/]+)$")
 	local parent = path:match("^.*%/([^/]+)/?$") -- Get the parent directory
-	-- if foo/ return bar
+	-- if foo/ return foo
 	if parent and not tail then
 		return parent
 	-- if foo/bar, return bar
@@ -43,9 +43,39 @@ local check_for_find_cmd = function()
 	return find_command
 end
 
+---@param path string
+---@return string
+-- should be used in the telescope adapter's manual_cd_project method
+local function format_dir_based_on_os(path)
+	-- the "before format" example belows are how paths are passed to api.add_project
+
+	local is_mac = vim.loop.os_uname().sysname == "Darwin"
+	-- local is_linux = vim.loop.os_uname().sysname == "Linux"
+	local is_windows = vim.loop.os_uname().sysname:find("Windows") and true or false
+
+	-- before format: /foo/barbuzz
+	-- after format: /foo/bar/buzz
+	if is_mac then
+		return vim.fn.expand("~") .. "/" .. path
+	end
+
+	-- before format: C:\User\namepathname
+	-- after format: C:\User\name\pathname
+	if is_windows then
+		return vim.fn.expand("~") .. "\\" .. path
+	end
+
+	-- Linux
+	-- before format: ./foo/bar/buzz
+	-- after format: /home/user/foo/bar/buzz
+	local format_linux_path = path:gsub("^%./", vim.fn.expand("~") .. "/")
+	return format_linux_path
+end
+
 return {
 	log_error = log_error,
 	get_tail_of_path = get_tail_of_path,
 	format_entry = format_entry,
 	check_for_find_cmd = check_for_find_cmd,
+	format_dir_based_on_os = format_dir_based_on_os,
 }

--- a/lua/cd-project/utils.lua
+++ b/lua/cd-project/utils.lua
@@ -6,7 +6,15 @@ end
 ---@param path string
 local function get_tail_of_path(path)
 	-- Remove leading directories, keep the last part
-	return path:match("([^/]+)$")
+	local tail = path:match("([^/]+)$")
+	local parent = path:match("^.*%/([^/]+)/?$") -- Get the parent directory
+	-- if foo/ return bar
+	if parent and not tail then
+		return parent
+	-- if foo/bar, return bar
+	else
+		return tail -- Return only the tail if there is no parent
+	end
 end
 
 ---@param project CdProject.Project
@@ -22,8 +30,22 @@ local function format_entry(project, max_len)
 	return string.format("%-" .. max_len .. "s", project.name) .. "  |  " .. project.path
 end
 
+local check_for_find_cmd = function()
+	local find_command = (function()
+		if 1 == vim.fn.executable("fd") then
+			return { "fd", "--type", "d", "--color", "never" }
+		elseif 1 == vim.fn.executable("fdfind") then
+			return { "fdfind", "--type", "d", "--color", "never" }
+		elseif 1 == vim.fn.executable("find") and vim.fn.has("win32") == 0 then
+			return { "find", ".", "-type", "d" }
+		end
+	end)()
+	return find_command
+end
+
 return {
 	log_error = log_error,
 	get_tail_of_path = get_tail_of_path,
 	format_entry = format_entry,
+	check_for_find_cmd = check_for_find_cmd,
 }

--- a/plugin/cd-project.lua
+++ b/plugin/cd-project.lua
@@ -16,4 +16,5 @@ vim.g.cd_project_current_project = api.find_project_dir()
 
 vim.api.nvim_create_user_command("CdProject", adapter.cd_project, {})
 vim.api.nvim_create_user_command("CdProjectAdd", api.add_current_project, {})
+vim.api.nvim_create_user_command("CdProjectManualAdd", adapter.manual_cd_project, {})
 vim.api.nvim_create_user_command("CdProjectBack", api.back, {})


### PR DESCRIPTION
## What does this PR do?
- Adds a new method to telescope and vim-ui adapters called `manual_cd_project`

### Telescope implementation
Uses `fd` or `find` command to search through list of directories starting from `$HOME` directory. This command will be used in `vim.fn.jobstart`. *see comment on why `cwd=vim.fn.expand("~")` is hardcoded*.

### Vim.ui implementation
Straight forward, uses a nested `vim.ui.input()` with simple data/error handling.

### Other addtions
- More robust `utils.get_tail_of_paths`
- New util method called `utils.check_for_find_cmd` to be used in telescope implementation

### TODOs
- Windows not supported due to hardcoded  `cwd=vim.fn.expand("~")`
- Further testing and iteration is needed.