### PR TITLE
feat: Add the option to format JSON with jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ return {
               return true
             end,
           },
-        },
-        format_json = false, -- optional, requires jq; whether to format the contents of the JSON file
+        } 
       })
     end,
   }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ return {
             end,
           },
         },
+        format_json = false, -- optional, requires jq; whether to format the contents of the JSON file
       })
     end,
   }

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -38,8 +38,7 @@ local default_config = {
         return true
       end,
     },
-  },
-  format_json = false, -- optional, requires jq; whether to format the contents of the JSON file
+  }
 }
 
 local M = {}

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -7,6 +7,7 @@
 ---@field choice_format? CdProject.ChoiceFormat
 ---@field projects_picker? CdProject.Adapter
 ---@field hooks? CdProject.Hook[]
+---@field format_json? boolean
 
 ---@type CdProject.Config
 local default_config = {

--- a/lua/cd-project/config.lua
+++ b/lua/cd-project/config.lua
@@ -38,6 +38,7 @@ local default_config = {
       end,
     },
   },
+  format_json = false, -- optional, requires jq; whether to format the contents of the JSON file
 }
 
 local M = {}

--- a/lua/cd-project/json.lua
+++ b/lua/cd-project/json.lua
@@ -3,6 +3,22 @@
 local write_json_file = function(tbl, path)
   local content = vim.fn.json_encode(tbl) -- Encoding table to JSON string
 
+  local format_json = vim.g.cd_project_config.format_json
+  if format_json ~= false then
+    local formatter = "jq"
+    if 0 == vim.fn.executable(formatter) then
+      error("The option format_json has been enabled but " .. formatter .. " was not found")
+    else
+      local fmt_cmd = { formatter, "--sort-keys", "--monochrome-output" }
+      local result = vim.system(fmt_cmd, { stdin = content }):wait()
+      if result.code ~= 0 then
+        error("Failed to format JSON with " .. formatter .. ": " .. result.stderr)
+        return nil
+      end
+      content = result.stdout
+    end
+  end
+
   local file, err = io.open(path, "w")
   if not file then
     error("Could not open file: " .. err)

--- a/lua/cd-project/json.lua
+++ b/lua/cd-project/json.lua
@@ -3,20 +3,15 @@
 local write_json_file = function(tbl, path)
   local content = vim.fn.json_encode(tbl) -- Encoding table to JSON string
 
-  local format_json = vim.g.cd_project_config.format_json
-  if format_json ~= false then
-    local formatter = "jq"
-    if 0 == vim.fn.executable(formatter) then
-      error("The option format_json has been enabled but " .. formatter .. " was not found")
-    else
-      local fmt_cmd = { formatter, "--sort-keys", "--monochrome-output" }
-      local result = vim.system(fmt_cmd, { stdin = content }):wait()
-      if result.code ~= 0 then
-        error("Failed to format JSON with " .. formatter .. ": " .. result.stderr)
-        return nil
-      end
-      content = result.stdout
+  local formatter = "jq"
+  if not (0 == vim.fn.executable(formatter)) then
+    local fmt_cmd = { formatter, "--sort-keys", "--monochrome-output" }
+    local result = vim.system(fmt_cmd, { stdin = content }):wait()
+    if result.code ~= 0 then
+      error("Failed to format JSON with " .. formatter .. ": " .. result.stderr)
+      return nil
     end
+    content = result.stdout
   end
 
   local file, err = io.open(path, "w")


### PR DESCRIPTION
Hello, thank you for creating this useful plugin! 

I've been using this simple change locally for a little while and it was quite useful so thought I'd open a PR for it. It just adds an option to format the JSON using `jq` when writing the JSON file (for people who sync to version control/want to update the file manually occasionally/etc.).