### PR TITLE
Properly call the hook callback in cd_project_in_tab

### DIFF
--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -90,7 +90,7 @@ local function cd_project_in_tab(dir)
 
   local hooks = cd_hooks.get_hooks(vim.g.cd_project_config.hooks, dir, "AFTER_CD")
   for _, hook in ipairs(hooks) do
-    hook(dir)
+    hook.callback(dir)
   end
 end
 


### PR DESCRIPTION
Thanks for the great plugin!

In the latest changes (b13ac125f08581ed57a083137c077589b154ac45), `cd_project_in_tab` hooks were broken because the hook table was being called, instead of the inner `callback` in the hook. This PR is a simple change to fix this.