### PR TITLE
Filter out non-existing projects

### DIFF
--- a/lua/cd-project/project-repo.lua
+++ b/lua/cd-project/project-repo.lua
@@ -6,7 +6,15 @@ local json = require("cd-project.json")
 
 ---@return CdProject.Project[]
 local get_projects = function()
-  return json.read_or_init_json_file(vim.g.cd_project_config.projects_config_filepath)
+  local json = json.read_or_init_json_file(vim.g.cd_project_config.projects_config_filepath)
+
+  -- Filter out projects whose directory does not exit
+  local existing_projects = vim.tbl_filter(function(p)
+    return vim.fn.isdirectory(p.path) == 1
+  end, json)
+
+  return existing_projects
+
 end
 
 ---@param projects CdProject.Project[]


### PR DESCRIPTION
In my use-case, I wish to use this project both on my local machine, and in instances of neovim in remote containers (docker, etc). I thus do not have the same folder structure in these environments, though some are in common.
For simplicity sake, I'd like to maintain a single list of projects, but only show the ones that actually exist on the environment in which my instance of neovim is currently running.

The change proposed in this PR does the job for me. We could make it optional but I don't really see the point as there is no reasonable action to do when trying to switch to a non-existing directory. It would either be do nothing or display an error, both of which are better served by not displaying the project in the first place. If we truly wish to do error handling, it should IMHO be done optionally at startup.