### PR TITLE
Sort by visited current last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the cd-project.nvim plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2025-05-18
+
+### Added
+- New feature to sort projects in the Telescope picker by last visited time (`visited_at`)
+- Current project is always placed at the bottom of the project list in the picker
+
+### Changed
+- Updated project data structure to include `visited_at` timestamp
+- Enhanced project retrieval to sort by last visited time
+- Modified `cd_project` function to update `visited_at` timestamp on project switch
+- Adjusted Telescope adapter to move the current project to the end of the list
+
+
 ## [0.11.0] - 2025-05-17
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,12 @@
-# cd-project.nvim v0.11.0 Release Notes
+# cd-project.nvim v0.12.0 Release Notes
 
 ## Major Changes
 
-### Project Position Tracking
-- Added functionality to remember the last position in a project, including the last opened file and cursor position
-- New configuration option `remember_project_position` to enable/disable this feature (enabled by default)
-- Added user commands for manual control:
-  - `CdProjectSavePosition`: Manually save the current position in the project
-  - `CdProjectRestorePosition`: Manually restore the saved position for the current project
-- Position is automatically saved when leaving a buffer or closing Vim, and restored when switching to a project
+### Project Sorting by Last Visited Time
+- Added functionality to sort projects in the Telescope picker by the last visited time (`visited_at`)
+- The current project is always placed at the bottom of the project list in the picker for easy access and visibility
 
-## Upgrading from v0.10.0
-No breaking changes in this release. The new position tracking feature is enabled by default. If you prefer not to use this feature, you can disable it in your configuration:
-```lua
-require("cd-project").setup({
-  remember_project_position = false
-})
-```
+## Upgrading from v0.11.0
+No breaking changes in this release. The new sorting by last visited time and positioning of the current project are automatically applied to the Telescope picker. No additional configuration is needed to use these features.
 
 For a complete list of changes, see the [CHANGELOG.md](CHANGELOG.md).

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -59,10 +59,22 @@ local cd_project = function(opts)
   opts = opts or {}
   local projects = repo.get_projects()
   local maxLength = 0
-  for _, project in ipairs(projects) do
+  -- Find the current project
+  local current_project_path = vim.fn.getcwd()
+  local current_project_index = nil
+  for i, project in ipairs(projects) do
     if #project.name > maxLength then
       maxLength = #project.name
     end
+    if project.path == current_project_path then
+      current_project_index = i
+    end
+  end
+
+  -- Move current project to the end of the list
+  if current_project_index then
+    local current_project = table.remove(projects, current_project_index)
+    table.insert(projects, current_project)
   end
 
   pickers

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -113,6 +113,16 @@ local function cd_project(dir, opts)
   local cd_cmd = opts.cd_cmd or "cd"
   vim.fn.execute(cd_cmd .. " " .. vim.fn.fnameescape(dir))
 
+  -- Update visited_at timestamp for the project
+  local projects = repo.get_projects()
+  for _, project in ipairs(projects) do
+    if project.path == dir then
+      project.visited_at = os.time()
+      break
+    end
+  end
+  repo.write_projects(projects)
+
   local hooks = cd_hooks.get_hooks(vim.g.cd_project_config.hooks, dir, "AFTER_CD")
   for _, hook in ipairs(hooks) do
     hook.callback(dir)

--- a/lua/cd-project/project-repo.lua
+++ b/lua/cd-project/project-repo.lua
@@ -5,18 +5,25 @@ local json = require("cd-project.json")
 ---@field desc string|nil
 ---@field last_file string|nil Path to last opened file (relative to project root)
 ---@field last_position number[]|nil Cursor position as [line, col]
+---@field visited_at number|nil Timestamp of last visit
 
 ---@return CdProject.Project[]
 local get_projects = function()
   local json = json.read_or_init_json_file(vim.g.cd_project_config.projects_config_filepath)
 
-  -- Filter out projects whose directory does not exit
+  -- Filter out projects whose directory does not exist
   local existing_projects = vim.tbl_filter(function(p)
     return vim.fn.isdirectory(p.path) == 1
   end, json)
 
-  return existing_projects
+  -- Sort projects by visited_at in descending order (most recent first)
+  table.sort(existing_projects, function(a, b)
+    local a_time = a.visited_at or 0
+    local b_time = b.visited_at or 0
+    return a_time > b_time
+  end)
 
+  return existing_projects
 end
 
 ---@param projects CdProject.Project[]


### PR DESCRIPTION
## Major Changes

### Project Sorting by Last Visited Time
- Added functionality to sort projects in the Telescope picker by the last visited time (`visited_at`)
- The current project is always placed at the bottom of the project list in the picker for easy access and visibility

## Upgrading from v0.11.0
No breaking changes in this release. The new sorting by last visited time and positioning of the current project are automatically applied to the Telescope picker. No additional configuration is needed to use these features.

For a complete list of changes, see the [CHANGELOG.md](CHANGELOG.md).

https://github.com/LintaoAmons/cd-project.nvim/issues/25
