### PR TITLE
Absolute Path Bug Fix + Light documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ return {
 | `CdProjectManualAdd` | Manually add a path and optionally give it a name                           |
 | `CdSearchAndAdd`     | fuzzy find directories in $HOME using telescope and optional give it a name |
 
+## Default Picker Keymaps
+
+| Map     | Action                               |
+| ------- | ------------------------------------ |
+| `<cr>`  | `cd` into project                    |
+| `<c-t>` | `tcd` into project (open in new tab) |
+| `<c-e>` | `lcd` into project (open in window)  |
+| `<c-d>` | Delete project                       |
+| `<c-r>` | Rename project                       |
+
 ## CONTRIBUTING
 
 Don't hesitate to ask me anything about the codebase if you want to contribute.

--- a/lua/cd-project/adapter/telescope.lua
+++ b/lua/cd-project/adapter/telescope.lua
@@ -111,7 +111,7 @@ function M.project_picker(callback, opts)
                 return
               end
               api.cd_project(selected.value.path, { cd_cmd = "tabe | tcd" })
-            end)
+            end, { desc = "Open in new tab" })
 
             actions.select_horizontal:replace(function()
               actions.close(prompt_bufnr)
@@ -140,7 +140,7 @@ function M.project_picker(callback, opts)
                 return
               end
               api.cd_project(selected.value.path, { cd_cmd = "lcd" })
-            end)
+            end, { desc = "Open in current window" })
 
             map({ "i", "n" }, "<c-d>", function()
               local selected = action_state.get_selected_entry()
@@ -151,7 +151,7 @@ function M.project_picker(callback, opts)
               actions.close(prompt_bufnr)
               -- Refresh the picker with updated project list
               start_picker(get_entries())
-            end)
+            end, { desc = "Remove project" })
 
             map({ "i", "n" }, "<c-r>", function()
               local selected = action_state.get_selected_entry()
@@ -169,7 +169,7 @@ function M.project_picker(callback, opts)
                   start_picker(get_entries())
                 end
               end)
-            end)
+            end, { desc = "Rename project" })
 
             return true
           end,

--- a/lua/cd-project/adapter/vim-ui.lua
+++ b/lua/cd-project/adapter/vim-ui.lua
@@ -53,7 +53,7 @@ local function cd_project_in_tab(opts)
 end
 
 local function manual_cd_project()
-  vim.ui.input({ prompt = "Add a project path: " }, function(path)
+  vim.ui.input({ prompt = "Add a project path: ", completion = "dir" }, function(path)
     if not path or path == "" then
       return utils.log_error("No path given, quitting.")
     end

--- a/lua/cd-project/api.lua
+++ b/lua/cd-project/api.lua
@@ -111,7 +111,8 @@ local function cd_project(dir, opts)
   end
 
   local cd_cmd = opts.cd_cmd or "cd"
-  vim.fn.execute(cd_cmd .. " " .. vim.fn.fnameescape(dir))
+  local full_command = cd_cmd .. " " .. vim.fn.fnameescape(dir)
+  vim.fn.execute(full_command)
 
   -- Update visited_at timestamp for the project
   local projects = repo.get_projects()
@@ -125,6 +126,9 @@ local function cd_project(dir, opts)
 
   -- Restore position for the new project
   position.restore_position(dir)
+
+  -- This will make the displayed names of the restored file appear relative to the root directory
+  vim.fn.execute(full_command)
 
   local hooks = cd_hooks.get_hooks(vim.g.cd_project_config.hooks, dir, "AFTER_CD", opts.cd_cmd)
   for _, hook in ipairs(hooks) do


### PR DESCRIPTION
Currently, after `cd`-ing into a project, the restored file's displayed path is not relative to the working directory:
<img width="1139" height="95" alt="image" src="https://github.com/user-attachments/assets/5d3b3ebe-6660-4e94-87a1-9e30f6c6dc73" />

This PR re-runs the `cd` command after restoring the position, fixing this issue. It also adds the default keymaps to the readme, since they are not well-documented.

It also adds file auto-completion to `CdProjectManualAdd` 